### PR TITLE
[💡]: Isolate GitHub Page Interests

### DIFF
--- a/app/(webhook)/github/_component/type.ts
+++ b/app/(webhook)/github/_component/type.ts
@@ -6,3 +6,14 @@ export type WebhookListProps = {
     copyId: number | null;
     copyToClipboard: (fullWebhookUrl: string, repositoryId: number) => void;
 };
+
+export type WebhookListToggleProps = {
+    isOpen: boolean;
+    onClick: () => void;
+};
+
+export type WebhookListContentProps = {
+    repoInfo: MyRepositoryListType[];
+    copyId: number | null;
+    copyToClipboard: (text: string, id: number) => void;
+};

--- a/app/(webhook)/github/_component/webhook-list-content.tsx
+++ b/app/(webhook)/github/_component/webhook-list-content.tsx
@@ -1,0 +1,38 @@
+import { WebhookListContentProps } from "./type";
+import WebhookList from "./webhook-list";
+
+/**
+ * 웹훅 목록을 표시하는 컴포넌트
+ * 각 레포지토리의 웹훅 정보를 리스트 형태로 렌더링
+ *
+ * @component
+ * @param {Object} props - 컴포넌트 props
+ * @param {Array<Repository>} props.repoInfo - 레포지토리 정보 배열
+ * @param {number|null} props.copyId - 현재 복사된 항목의 ID
+ * @param {function} props.copyToClipboard - 웹훅 URL을 클립보드에 복사하는 함수
+ */
+
+const WebhookListContent = ({
+    repoInfo,
+    copyId,
+    copyToClipboard,
+}: WebhookListContentProps) => {
+    return (
+        <div className="w-full flex justify-start">
+            {repoInfo.map((item) => {
+                const fullWebhookUrl = `${process.env.NEXT_PUBLIC_API_URL}/${item.webhookUrl}`;
+                return (
+                    <WebhookList
+                        key={item.repositoryId}
+                        item={item}
+                        fullWebhookUrl={fullWebhookUrl}
+                        copyId={copyId}
+                        copyToClipboard={copyToClipboard}
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+export default WebhookListContent;

--- a/app/(webhook)/github/_component/webhook-list-toggle.tsx
+++ b/app/(webhook)/github/_component/webhook-list-toggle.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import { WebhookListToggleProps } from "./type";
+
+/**
+ * 웹훅 리스트를 토글하는 버튼 컴포넌트
+ * 클릭 시 웹훅 리스트를 표시하거나 숨기며, 화살표 아이콘의 방향이 변경됨
+ *
+ * @component
+ * @param {Object} props
+ * @param {boolean} props.isOpen - 웹훅 리스트의 표시 상태
+ * @param {() => void} props.onClick - 토클 버튼 클릭 핸들러
+ *
+ * @returns
+ */
+const WebhookListToggle = ({ isOpen, onClick }: WebhookListToggleProps) => {
+    return (
+        <div
+            className="w-[130px] h-[44px] font-semibold text-[16px] bg-SYSTEM-black text-GREY-10 rounded-lg flex-center cursor-pointer"
+            onClick={onClick}
+        >
+            <p className="pr-2">웹훅 리스트</p>
+            <Image
+                src={"/light/icons/up-arrow.svg"}
+                alt="UP"
+                width={20}
+                height={20}
+                className={isOpen ? "transform scale-y-[-1]" : ""}
+            />
+        </div>
+    );
+};
+export default WebhookListToggle;

--- a/app/(webhook)/github/page.tsx
+++ b/app/(webhook)/github/page.tsx
@@ -5,38 +5,17 @@ import PageDescription from "@/components/layout/tab/page-desc";
 import StepTemplate from "@/components/common/step-template";
 import { GitHubWebHook } from "@/constants/steps/github";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { getMyRepositoryList } from "@/apis/repository";
-import { MyRepositoryListType } from "@/type/user";
-import WebhookList from "./_component/webhook-list";
-import Image from "next/image";
-import { userStore, useUserStore } from "@/libs/zustand/user";
+import { useState } from "react";
+import { useRepository } from "@/hook/useRepository";
+import { useClipboard } from "@/hook/useClipboard";
+import WebhookListToggle from "./_component/webhook-list-toggle";
+import WebhookListContent from "./_component/webhook-list-content";
 
 const RegisterGitHub = () => {
     const router = useRouter();
-
-    const [repoInfo, setRepoInfo] = useState<MyRepositoryListType[]>([]);
-    const [copyId, setCopyId] = useState<number | null>(null);
+    const { repoInfo } = useRepository();
+    const { copyId, copyToClipboard } = useClipboard();
     const [isHookList, setIsHookList] = useState(true);
-    const { login } = useUserStore();
-
-    useEffect(() => {
-        const fetchRepository = async () => {
-            if (!login) {
-                throw new Error("유저정보를 받아오지 못했습니다.");
-            }
-            const response = await getMyRepositoryList(login);
-            setRepoInfo(response.data);
-        };
-        fetchRepository();
-    }, []);
-
-    const copyToClipboard = (text: string, id: number) => {
-        navigator.clipboard.writeText(text).then(() => {
-            setCopyId(id);
-            setTimeout(() => setCopyId(null), 2000);
-        });
-    };
 
     const handleHookList = () => {
         setIsHookList(!isHookList);
@@ -50,46 +29,17 @@ const RegisterGitHub = () => {
                 content="웹훅 등록 방법 안내"
             />
             <div className="w-[1280px] mt-12">
-                <div
-                    className="w-[130px] h-[44px] font-semibold text-[16px] bg-SYSTEM-black text-GREY-10 rounded-lg flex-center cursor-pointer"
+                <WebhookListToggle
+                    isOpen={isHookList}
                     onClick={handleHookList}
-                >
-                    <p className="pr-2">웹훅 리스트</p>
-                    {isHookList ? (
-                        <Image
-                            src={"/light/icons/up-arrow.svg"}
-                            width={20}
-                            height={20}
-                            alt="UP"
-                            className="transform scale-y-[-1]"
-                        />
-                    ) : (
-                        <Image
-                            src={"/light/icons/up-arrow.svg"}
-                            width={20}
-                            height={20}
-                            alt="UP"
-                        />
-                    )}
-                </div>
+                />
 
-                {isHookList ? (
-                    <div></div>
-                ) : (
-                    <div className="w-full flex justify-start">
-                        {repoInfo.map((item) => {
-                            const fullWebhookUrl = `${process.env.NEXT_PUBLIC_API_URL}/${item.webhookUrl}`;
-                            return (
-                                <WebhookList
-                                    key={item.repositoryId}
-                                    item={item}
-                                    fullWebhookUrl={fullWebhookUrl}
-                                    copyId={copyId}
-                                    copyToClipboard={copyToClipboard}
-                                />
-                            );
-                        })}
-                    </div>
+                {isHookList && (
+                    <WebhookListContent
+                        repoInfo={repoInfo}
+                        copyId={copyId}
+                        copyToClipboard={copyToClipboard}
+                    />
                 )}
             </div>
 

--- a/app/[userId]/repo-list/_components/fetch-repo-list.tsx
+++ b/app/[userId]/repo-list/_components/fetch-repo-list.tsx
@@ -28,6 +28,10 @@ const FetchRepositoryList = () => {
 
     if (!repositories) return <div>데이터가 없습니다</div>;
 
+    const handleDelete = async () => {
+        await deleteFetchRepository(43);
+    };
+
     return (
         <>
             {repositories.data.map((repo, index) => (
@@ -38,6 +42,7 @@ const FetchRepositoryList = () => {
                     <p className="flex-[3]">{ShortenText(repo.fullName, 50)}</p>
                     <p className="flex-[1.5]">{repo.ownerLogin}</p>
                     {/* <p className="flex-[1.5]">{repo.assignee}</p> */}
+                    <button onClick={handleDelete}>삭제</button>
                 </li>
             ))}
         </>

--- a/hook/useClipboard.ts
+++ b/hook/useClipboard.ts
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+export const useClipboard = () => {
+    const [copyId, setCopyId] = useState<number | null>(null);
+
+    const copyToClipboard = (text: string, id: number) => {
+        navigator.clipboard.writeText(text).then(() => {
+            setCopyId(id);
+            setTimeout(() => setCopyId(null), 2000);
+        });
+    };
+
+    return { copyId, copyToClipboard };
+};

--- a/hook/useClipboard.ts
+++ b/hook/useClipboard.ts
@@ -1,5 +1,14 @@
 import { useState } from "react";
 
+/**
+ * 클립보드 복사 기능을 제공하는 커스텀 훅
+ * 복사 성공 시 복사된 항목의 ID를 2초간 표시
+ *
+ * @returns {Object} 클립보드 관련 상태와 함수를 포함한 객체
+ * @property {number|null} copyId - 현재 복사된 항목의 ID
+ * @property {function} copyToClipboard - 텍스트를 클립보드에 복사하는 함수
+ */
+
 export const useClipboard = () => {
     const [copyId, setCopyId] = useState<number | null>(null);
 

--- a/hook/useRepository.ts
+++ b/hook/useRepository.ts
@@ -1,0 +1,31 @@
+import { getMyRepositoryList } from "@/apis/repository";
+import { useUserStore } from "@/libs/zustand/user";
+import { MyRepositoryListType } from "@/type/user";
+import { useEffect, useState } from "react";
+
+/**
+ * My Repository 정보를 받아오는 커스텀 훅
+ *
+ * @returns {Object} 내 레포지토리 정보를 담은 객체
+ * @property {MyRepositoryListType[]} repoInfo - 사용자의 레포지토리 정보 배열
+ *
+ * @throws {Error} 로그인 정보가 없는 경우 에러를 발생
+ */
+
+export const useRepository = () => {
+    const [repoInfo, setRepoInfo] = useState<MyRepositoryListType[]>([]);
+    const { login } = useUserStore();
+
+    useEffect(() => {
+        const fetchRepository = async () => {
+            if (!login) {
+                throw new Error("유저 정보를 받아오지 못했습니다.");
+            }
+            const response = await getMyRepositoryList(login);
+            setRepoInfo(response.data);
+        };
+        fetchRepository();
+    }, [login]);
+
+    return { repoInfo };
+};


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->

- github-page의 관심사 분리

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->

- 기존에 100줄이 넘던 github-page의 관심사를 분리하였습니다
- 2개의 컴포넌트와 2개의 커스텀 훅이 생성 되었습니다.

![스크린샷 2024-10-23 오후 11 07 21](https://github.com/user-attachments/assets/1c0c1138-12db-43bf-b378-07046a2068cc)

- 웹훅 목록을 표시하는 컴포넌트와 웹훅 리스트를 토글하는 컴포넌트로 나누었습니다.

![스크린샷 2024-10-23 오후 11 07 37](https://github.com/user-attachments/assets/ba06c13d-d341-4fe4-85e6-19fd3892ea0c)

- 클립보드 복사 기능을 제공하는 커스텀훅과 My Repository 정보를 받아오는 커스텀 훅을 작성했습니다.

<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이걸 PR이라고 올렸어요? 당장 수정해주시죠!?"
  - [ ] : "🥹 이건 좀..."
  - [ ] : "🤷 PR하기 전에 생각했나요?"

# Description

```