### PR TITLE
[💡]: webhook messenger 

### DIFF
--- a/app/(webhook)/messengers/_components/register-tab.tsx
+++ b/app/(webhook)/messengers/_components/register-tab.tsx
@@ -4,8 +4,11 @@ import DeliverButton from "@/components/common/button";
 import DeliverInput from "@/components/common/input";
 import MessengerSelector from "./register/select-container";
 import { useMessengerRegistration } from "@/hook/use-messenger-registration";
+import DeliverModal from "@/components/common/modal";
+import { useRouter } from "next/navigation";
 
 const RegisterTab = () => {
+    const router = useRouter();
     const {
         control,
         handleSubmit,
@@ -13,32 +16,56 @@ const RegisterTab = () => {
         onSubmit,
         selectedMessengerType,
         onMessengerTypeChange,
+        isMessengerSuccess,
+        setIsMessengerSuccess,
     } = useMessengerRegistration();
 
+    const handleAlert = () => {
+        alert("등록한 레포지토리 삭제 후 처음부터 다시 시도해주세요.");
+    };
+
     return (
-        <div className="min-h-[648px] flex-justify">
-            <form onSubmit={handleSubmit(onSubmit)}>
-                <MessengerSelector
-                    register={register}
-                    selectedMessengerType={selectedMessengerType}
-                    onMessengerTypeChange={onMessengerTypeChange}
+        <>
+            {isMessengerSuccess && (
+                <DeliverModal
+                    isSuccess={true}
+                    isOpen={isMessengerSuccess}
+                    onClose={() => setIsMessengerSuccess(false)}
+                    onConfirm={() => {
+                        router.push("/user-dashborad");
+                    }}
+                    onReturn={handleAlert}
+                    title="메신저 등록 완료"
+                    content="메신저 등록이 완료되었습니다."
+                    content2="메세지가 도착했는지 확인해주세요."
+                    buttonText={"메시지가 왔어요"}
+                    returnButtonText="다시 보내주세요"
                 />
-                <div className="mb-10">
-                    <DeliverInput
-                        name="webhookUrl"
-                        control={control}
-                        title="웹훅 URL 입력"
-                        placeholder="ex) https://discord.com/api/webhooks/12745805631387/s-AC"
+            )}
+            <div className="min-h-[648px] flex-justify">
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <MessengerSelector
+                        register={register}
+                        selectedMessengerType={selectedMessengerType}
+                        onMessengerTypeChange={onMessengerTypeChange}
                     />
-                </div>
-                <DeliverButton
-                    label="등록하기"
-                    length="full"
-                    onClick={handleSubmit(onSubmit)}
-                    isModal={false}
-                />
-            </form>
-        </div>
+                    <div className="mb-10">
+                        <DeliverInput
+                            name="webhookUrl"
+                            control={control}
+                            title="웹훅 URL 입력"
+                            placeholder="ex) https://discord.com/api/webhooks/12745805631387/s-AC"
+                        />
+                    </div>
+                    <DeliverButton
+                        label="등록하기"
+                        length="full"
+                        onClick={handleSubmit(onSubmit)}
+                        isModal={false}
+                    />
+                </form>
+            </div>
+        </>
     );
 };
 export default RegisterTab;

--- a/app/[userId]/repo-list/_components/fetch-repo-list.tsx
+++ b/app/[userId]/repo-list/_components/fetch-repo-list.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { RepositoryData } from "@/apis/type";
-import { getMyRepositoryList } from "@/apis/repository";
+import { deleteFetchRepository, getMyRepositoryList } from "@/apis/repository";
 import { getSessionStorageObject } from "@/utils/storage";
 import { ShortenText } from "@/utils/shorten-text";
 import { UserInfoType } from "@/app/user-dashboard/type";
@@ -29,7 +29,9 @@ const FetchRepositoryList = () => {
         fetchMyRepositories();
     }, []);
 
-    // const handleDelete = async () => {await deleteFetchRepository(48);};
+    // const handleDelete = async () => {
+    //     await deleteFetchRepository(55);
+    // };
 
     if (!repositories) return <EmptyRepoList />;
     return (
@@ -45,6 +47,7 @@ const FetchRepositoryList = () => {
                     <p className="text-[13px] font-normal text-GREY-80">
                         {ShortenText(repo.fullName, 50)}
                     </p>
+                    {/* <button onClick={handleDelete}>삭제</button> */}
                 </li>
             ))}
         </ul>

--- a/app/activate/page.tsx
+++ b/app/activate/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { postFetchEnc } from "@/apis/messenger";
+import DeliverButton from "@/components/common/button";
+import DeliverModal from "@/components/common/modal";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+const ActivePage = () => {
+    const router = useRouter();
+    const urlParams = new URLSearchParams(window.location.search);
+    const encryptedWebhookUrl = urlParams.get("encryptedWebhookUrl");
+
+    const [isError, setIsError] = useState(false);
+    const [isSuccess, setIsSuccess] = useState(false);
+
+    const handleMessengerActive = async () => {
+        try {
+            const response = await postFetchEnc(encryptedWebhookUrl);
+            if (response.status === 200) {
+                setIsSuccess(true);
+            }
+        } catch {
+            setIsError(true);
+        }
+    };
+
+    const handleSuccess = () => {
+        setIsSuccess(false);
+        router.push("/user-dashboard");
+    };
+
+    return (
+        <div>
+            {isSuccess && (
+                <DeliverModal
+                    isSuccess={true}
+                    isOpen={isSuccess}
+                    onClose={handleSuccess}
+                    onConfirm={() => setIsSuccess(false)}
+                    title="메신저 활성화에 성공했습니다."
+                    content=""
+                    buttonText="확인"
+                />
+            )}
+            {isError && (
+                <DeliverModal
+                    isSuccess={false}
+                    isOpen={isError}
+                    onClose={() => setIsError(false)}
+                    onConfirm={() => setIsError(false)}
+                    title="메신저 활성화에 실패했습니다."
+                    content=""
+                    buttonText="확인"
+                />
+            )}
+            <div className=" w-full h-[calc(100vh-180px)] flex-center flex-col">
+                <Image
+                    src={"/images/octo-cat.png"}
+                    alt="logo"
+                    width={300}
+                    height={500}
+                />
+                <div className=" w-[1280px] flex-center mt-12">
+                    <div className="flex-center w-full cursor-pointer ">
+                        <DeliverButton
+                            onClick={handleMessengerActive}
+                            length="full"
+                            label="메신저 활성화"
+                            isModal={false}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+export default ActivePage;

--- a/components/common/button.tsx
+++ b/components/common/button.tsx
@@ -12,6 +12,8 @@ import "@/styles/button.css";
  * @param {string} type - 버튼의 타입을 지정. 기본값은 button
  * @param {boolean} [isModal = false] - 버튼 종류를 결정하는 플래그. true일 경우 모달 버튼 스타일 적용
  * @param {string} [buttonBgColor] - isModal이 true일 경우, 적용될 버튼의 배경 색상
+ * @param {string} [buttonTextColor] - isModal이 ture일 경우, 적용될 버튼의 글자 색상
+ * @param {boolean} [buttonActive = true] - 버튼의 활성화의 제어를 결정하며 기본값은 true 
 
  * @returns {JSX.Element} 버튼 컴포넌트를 반환
  */
@@ -23,10 +25,12 @@ const DeliverButton = ({
     type = "button",
     isModal,
     buttonBgColor,
+    buttonTextColor,
+    buttonActive = true,
 }: DeliverButtonProps) => {
     // 버튼이 적용될 위치에 따라 달라지는 css
     const baseCSS = "relative overflow-hidden group";
-    const modalCSS = `w-[320px] h-[44px] rounded-lg text-SYSTEM-white ${buttonBgColor}`;
+    const modalCSS = `w-[320px] h-[44px] rounded-lg ${buttonTextColor} ${buttonBgColor}`;
     const confirmButtonCSS = `h-[52px] rounded-[10px] ${
         isActive ? "text-GREY-10 bg-BRAND-50" : "text-GREY-20 bg-GREY-30"
     } ${length === "full" ? "w-[416px]" : "w-[200px]"}`;
@@ -37,7 +41,7 @@ const DeliverButton = ({
             onClick={onClick}
             className={`${baseCSS} ${isModal ? modalCSS : confirmButtonCSS}`}
         >
-            <span className="custom-hover-effect" />
+            <span className={buttonActive ? "custom-hover-effect" : ""} />
             <p className="relative z-10">{label}</p>
         </button>
     );

--- a/components/common/modal.tsx
+++ b/components/common/modal.tsx
@@ -12,36 +12,45 @@ import DeliverButton from "./button";
  * @param {boolean} isSuccess - 성공 여부에 따라 다른 아이콘과 스타일을 적용
  * @param {boolean} isOpen - 모달이 열려 있는지 여부
  * @param {Function} onClose - 모달을 닫을 때 호출되는 함수
+ * @param {Function} onReturn - 모달을 닫거나 취소 시 호출되는 함수
  * @param {Function} onConfirm - 확인 버튼을 눌렀을 때 호출되는 함수
  * @param {string} title - 모달의 제목
  * @param {string} content - 모달의 본문 내용
+ * @param {string} content2 - 모달의 두번째 본문 내용
+ * @param {Function} returnButtonText - 모달의 취소 및 닫을 때 호출되는 함수
  */
 const DeliverModal = ({
     isSuccess,
     isOpen,
     onClose,
+    onReturn,
     onConfirm,
     title,
     content,
+    content2,
     buttonText,
+    returnButtonText,
 }: DeliverModalProps) => {
     // success 여부에 따라 달라지는 css
     const Icon = isSuccess ? SUCCESS : ERROR;
     const IconBG = isSuccess ? "bg-BRAND-30" : "bg-ERROR-10";
     const buttonBgColor = isSuccess ? "bg-BRAND-50" : "bg-ERROR-50";
+    const successButtonBgColor = isSuccess ? "bg-BRAND-30" : "";
 
     if (!isOpen) return null;
     return (
         <Overlay isOpen={isOpen} onClick={onClose}>
             <div className="relative w-[360px] h-full rounded-2xl p-5 bg-SYSTEM-white">
-                <Image
-                    width={24}
-                    height={24}
-                    src={"/icons/close.svg"}
-                    alt="close modal"
-                    className="absolute right-5"
-                    onClick={onClose}
-                />
+                <div className=" cursor-pointer">
+                    <Image
+                        width={24}
+                        height={24}
+                        src={"/icons/close.svg"}
+                        alt="close modal"
+                        className="absolute right-5"
+                        onClick={onClose}
+                    />
+                </div>
                 <div className="flex-center flex-col mt-1">
                     <div
                         className={`w-[60px] h-[60px] rounded-full flex-center ${IconBG}`}
@@ -58,13 +67,35 @@ const DeliverModal = ({
                         <p className="text-[14px] text-center">
                             {ShortenText(content, 80)}
                         </p>
+                        {content2 && (
+                            <p className="text-[14px] text-center">
+                                {ShortenText(content2, 80)}
+                            </p>
+                        )}
                     </div>
-                    <DeliverButton
-                        onClick={onConfirm}
-                        label={buttonText}
-                        isModal={true}
-                        buttonBgColor={buttonBgColor}
-                    />
+                    <div
+                        className={`${
+                            isSuccess ? " w-full flex flex-row gap-3" : ""
+                        }`}
+                    >
+                        {isSuccess && returnButtonText && (
+                            <DeliverButton
+                                onClick={onReturn}
+                                label={returnButtonText}
+                                isModal={true}
+                                buttonBgColor={successButtonBgColor}
+                                buttonTextColor="text-BRAND-50"
+                                buttonActive={false}
+                            />
+                        )}
+                        <DeliverButton
+                            onClick={onConfirm}
+                            label={buttonText}
+                            isModal={true}
+                            buttonBgColor={buttonBgColor}
+                            buttonTextColor={"text-SYSTEM-white"}
+                        />
+                    </div>
                 </div>
             </div>
         </Overlay>

--- a/components/common/type.ts
+++ b/components/common/type.ts
@@ -16,6 +16,8 @@ export type DeliverButtonProps = {
     type?: "button" | "submit";
     isModal: boolean;
     buttonBgColor?: string;
+    buttonTextColor?: string;
+    buttonActive?: boolean;
 };
 
 export type CustomInputProps = {
@@ -34,8 +36,11 @@ export type DeliverModalProps = {
     isSuccess: boolean;
     isOpen: boolean;
     onClose: () => void;
+    onReturn?: () => void;
     onConfirm: () => void;
     title: string;
     content: string;
+    content2?: string;
     buttonText: string;
+    returnButtonText?: string;
 };

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -5,7 +5,9 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     return (
         <div className="h-full flex flex-col">
             <Header />
-            <main className="flex-grow mt-[60px]">{children}</main>
+            <main className=" min-h-[calc(100vh-60px-120px)] mt-[60px]">
+                {children}
+            </main>
             <Footer />
         </div>
     );

--- a/hook/type.ts
+++ b/hook/type.ts
@@ -13,4 +13,6 @@ export type MessengerRegistrationReturnType = {
     onSubmit: (data: MessengerFormFields) => Promise<void>;
     selectedMessengerType: string;
     onMessengerTypeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    isMessengerSuccess: boolean;
+    setIsMessengerSuccess: (isMessengerSuccess: boolean) => void;
 };

--- a/hook/use-messenger-registration.ts
+++ b/hook/use-messenger-registration.ts
@@ -18,9 +18,9 @@ import { MessengerFormFields } from "@/type/messenger";
  * - onMessengerTypeChange: 메신저 타입 변경 시 호출되는 함수
  */
 export const useMessengerRegistration = (): MessengerRegistrationReturnType => {
-    const router = useRouter();
     const { control, handleSubmit, register } = useForm<MessengerFormFields>();
     const [selectedMessengerType, setSelectedMessengerType] = useState("");
+    const [isMessengerSuccess, setIsMessengerSuccess] = useState(false);
     const repositoryId = Number(getSessionStorage("repositoryId"));
 
     /**
@@ -43,15 +43,9 @@ export const useMessengerRegistration = (): MessengerRegistrationReturnType => {
             webhookUrl,
         });
         if (response.status === "Success") {
-            const responseMessenger = await postFetchEnc(
-                response.data.encryptedWebhookUrl
-            );
-            if (responseMessenger.status === 200) {
-                alert(
-                    "메신저 활성화에 성공했습니다. 메인 페이지로 이동합니다."
-                );
-                router.push("/");
-            }
+            setIsMessengerSuccess(true);
+        } else {
+            setIsMessengerSuccess(false);
         }
     };
 
@@ -62,5 +56,7 @@ export const useMessengerRegistration = (): MessengerRegistrationReturnType => {
         onSubmit,
         selectedMessengerType,
         onMessengerTypeChange,
+        isMessengerSuccess,
+        setIsMessengerSuccess,
     };
 };


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->

- 모달과 공용 컴포넌트 버튼 리팩터링
- 메신저 웹훅 등록 리팩터링


<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->

![스크린샷 2024-11-02 오후 10 24 17](https://github.com/user-attachments/assets/dd033705-75de-43c8-aa45-725113784fd1)

- 기존에 메신저 등록 시 바로 메신저가 활성화가 되던 방식에서 메신저가 등록되고 메시지가 왔다는 모달을 보여줍니다.
- 해당 기능을 위해 딜리버 모달을 수정했습니다.

![스크린샷 2024-11-02 오후 10 31 05](https://github.com/user-attachments/assets/9f6cf2c2-cec1-4fd0-90de-e46093ddb489)

- 성공 모달일 때, 버튼을 두 개가 생길 수 있도록 수정했습니다.
- 메시지가 왔어요 버튼 클릭시 user-dashboard로 리다이렉트됩니다.
- 다시 보내주세요 버튼 클릭시 alert로 처음부터 다시 시작해야된다는 문구를 보여줍니다.
- 두 예시 모두 해당 기능과 디자인이 없어 우선 임의로 넣어두었습니다.

![스크린샷 2024-11-02 오후 10 44 59](https://github.com/user-attachments/assets/8b2181e0-cb36-4c98-9898-97a13f4b7148)

- 버튼도 색상 및 활성화에 대한 수정이 이루어졌습니다.

<hr/>

![스크린샷 2024-11-02 오후 10 24 48](https://github.com/user-attachments/assets/801d020a-def7-48e9-bf29-1fcb2531b0b4)

![스크린샷 2024-11-02 오후 10 25 07](https://github.com/user-attachments/assets/a68f2ed1-f807-473c-958e-10f404d49313)

- 해당 링크 클릭 시, 메신저 활성화 페이지로 리다이렉트됩니다.
- 해당 페이지는 디자인이 없어서 우선 임의로 만들어두었습니다.

![스크린샷 2024-11-02 오후 10 25 11](https://github.com/user-attachments/assets/87e9a2a2-8f79-4298-b983-ff9113557316)

- 활성화 버튼 클릭 시, 메신저가 활성화되면 성공 모달이 실패하면 실패 모달이 보여집니다.


<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이걸 PR이라고 올렸어요? 당장 수정해주시죠!?"
  - [ ] : "🥹 이건 좀..."
  - [ ] : "🤷 PR하기 전에 생각했나요?"

# Description

```