### PR TITLE
[🎁] : re-publish layout style (exclude footer from viewport)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -43,3 +43,19 @@ body {
         text-wrap: balance;
     }
 }
+
+/* scroll */
+Untitled
+
+/* 스크롤바 숨기기 */
+.hide-scrollbar {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+}
+
+.hide-scrollbar::-webkit-scrollbar {
+    display: none; /* WebKit (Chrome, Safari) */
+}

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -3,9 +3,9 @@ import Header from "./header";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     return (
-        <div className="h-full flex flex-col">
+        <div className="flex flex-col">
             <Header />
-            <main className=" min-h-[calc(100vh-60px-120px)] mt-[60px]">
+            <main className="max-h-[calc(100vh-60px-120px)] mt-[60px] overflow-hidden">
                 {children}
             </main>
             <Footer />

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -3,12 +3,12 @@ import Header from "./header";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     return (
-        <div className="flex flex-col">
+        <div className="h-screen flex flex-col">
             <Header />
-            <main className="max-h-[calc(100vh-60px-120px)] mt-[60px] overflow-hidden">
-                {children}
+            <main className="h-full flex-1 overflow-y-scroll hide-scrollbar">
+                <div className="h-full mt-[60px]">{children}</div>
+                <Footer />
             </main>
-            <Footer />
         </div>
     );
 };


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->
레이아웃 스타일이 꼬여서 과하게 스크롤이 생겼던 부분 수정했습니다.

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->

###### [🎁style : 뷰포트에 맞추기](https://github.com/ThugDev/PR-Deliver/commit/9991ea7a6c613b4390973d3a9f3c74759bf29e12)

레포지토리 목록을 보는 페이지에서 메인 부분의 스크롤이 과하게 길었던 문제가 있었습니다.
해당 부분을 뷰포트에 맞춰 스크롤이 생기지 않도록 변경했어요.

<img width="1813" alt="viewport" src="https://github.com/user-attachments/assets/55f4803f-5dca-455f-ab96-a4eb9206af66">

<br/>

###### [🎁 styles: 뷰포트에서 푸터 제외 레이아웃으로 변경](https://github.com/ThugDev/PR-Deliver/commit/905c78a7f45b0441bfb5c7db8f605f238a2365b8)

디자이너 님께 확인 받은 결과, footer는 랜딩 페이지를 제외하고 필수로 화면에 보일 필요가 없다는 의견을 전달 받았습니다.
따라서 뷰포트에서 footer가 보이지 않도록 수정했습니다.

메인 컨텐츠는 뷰포트 만큼의 높이를 갖도록 설정했고, footer의 높이만큼 스크롤할 수 있습니다.


https://github.com/user-attachments/assets/fbe2a85e-cd98-41fa-ac58-c816a3e0cc7c


<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이걸 PR이라고 올렸어요? 당장 수정해주시죠!?"
  - [ ] : "🥹 이건 좀..."
  - [ ] : "🤷 PR하기 전에 생각했나요?"

# Description

```
