### PR TITLE
[🐞]: Specify layout body sliding and image size

### DIFF
--- a/components/common/step-template.tsx
+++ b/components/common/step-template.tsx
@@ -18,7 +18,13 @@ const StepTemplate = ({
                 className={"relative w-full flex flex-col"}
                 style={{ height: `${imageHeight}px` }}
             >
-                <Image sizes="auto" src={imageSrc} alt="each step's image" />
+                <Image
+                    sizes="auto"
+                    src={imageSrc}
+                    fill
+                    alt="each step's image"
+                    className="w-auto h-auto"
+                />
             </div>
             {imageDesc && (
                 <p className="text-sm text-GREY-60 pt-3 pl-1">{imageDesc}</p>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -3,12 +3,12 @@ import Header from "./header";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
     return (
-        <div className="h-screen flex flex-col">
+        <div className="min-h-screen flex flex-col">
             <Header />
             <main className="h-full flex-1 overflow-y-scroll hide-scrollbar">
                 <div className="h-full mt-[60px]">{children}</div>
-                <Footer />
             </main>
+            <Footer />
         </div>
     );
 };


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->

- 레이아웃 본문 밀림 현상 수정
- github 페이지의 Image 크기가 정해져있지 않아 발생하는 오류 해결

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->

![스크린샷 2024-12-09 오후 11 03 06](https://github.com/user-attachments/assets/5eb2bace-8a42-4d2c-ac7d-69dfeefbafd8)

- `h-screen`을 `min-h-screen`으로 변경하였습니다.
`min-h-screen`으로 작성한 이유는 `h-screen`는 전체 뷰포트 높이를 100%로 설정하지만, 내부 요소의 높이가 적절히 분배되지 않으면 의도치 않은 빈 공간이 생길 수 있다고 합니다.
그래서 `min-h-screen`을 사용하여 콘텐츠가 적어도 화면 전체 높이를 채우도록 했습니다.


https://github.com/user-attachments/assets/eccfeead-1bc7-4969-b493-29b6757bbd84

- `<Footer>`를 `<main>`의 바깥으로 이동하였습니다.

![스크린샷 2024-12-09 오후 11 06 47](https://github.com/user-attachments/assets/6359ce84-d53c-4d6a-b474-bf78fe1596a5)

- `sizes="auto"`로는 크기가 확실히 정해지지 않아 fill을 사용하여 부모 컴포넌트의 사이즈를 따라가도록 수정했습니다.

<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이걸 PR이라고 올렸어요? 당장 수정해주시죠!?"
  - [ ] : "🥹 이건 좀..."
  - [ ] : "🤷 PR하기 전에 생각했나요?"

# Description

```
